### PR TITLE
Fix typo in URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Badreads is a book tracking Android application for logging books
 you're reading, read, and want to read. Your library "shelves" (reading, read, and to read)
 are stored locally on your phone. Use the search or barcode reader to look up
-new book on [OpenLibrary](https://openlibary.org) and add it to your library. You can
+new book on [OpenLibrary](https://openlibrary.org) and add it to your library. You can
 import and export your library from or to Open Library and Goodreads.
 
 Badreads is very unstable. I recommend backing up with an export before installing updates or changes.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,7 +1,7 @@
 Badreads is a book tracking Android application for logging books
 you're reading, read, and want to read. Your library "shelves" (reading, read, and to read)
 are stored locally on your phone. Use the search or barcode reader to look up
-new book on [OpenLibrary](https://openlibary.org) and add it to your library.
+new book on [OpenLibrary](https://openlibrary.org) and add it to your library.
 You can import and export your library from or to Open Library and Goodreads.
 
 Badreads is unstable. I recommend backing up with an export before installing updates or changes.


### PR DESCRIPTION
Hi! This PR fixes a typo in the OpenLibrary URL in the README which accidentally pointed to a scam site.